### PR TITLE
Fix the capitalization of "GitHub".

### DIFF
--- a/README.mkdn
+++ b/README.mkdn
@@ -1,17 +1,17 @@
-# Github Meets CPAN
+# GitHub Meets CPAN
 
 [github-meets-cpan](http://gh.metacpan.org/)
 
-This project connects Github Users to MetaCPAN Users. It uses the
+This project connects GitHub Users to MetaCPAN Users. It uses the
 APIs of both sites: First it fetches all users from [MetaCPAN][metacpan] who
-have set their Github account. After that it fetches all public
-information about these users from Github.
+have set their GitHub account. After that it fetches all public
+information about these users from GitHub.
 
 It uses [MongoDB][mongo] for storing the data.
 The software is written in Perl using the [Mojolicious][mojo] framework.
 The app was originally deployed to dotCloud, but is now hosted on metacpan servers.
 
-It's some sort of an index of CPAN authors and their Github
+It's some sort of an index of CPAN authors and their GitHub
 accounts.
 
 [mojo]: http://mojolicious.org/

--- a/lib/GMC/Cron/Update.pm
+++ b/lib/GMC/Cron/Update.pm
@@ -130,7 +130,7 @@ sub fetch_github_user {
 
     my $github_user = $user->{github_user};
     unless ($github_user) {
-        $self->log->error( sprintf '%-9s Invalid Github user: %s',
+        $self->log->error( sprintf '%-9s Invalid GitHub user: %s',
             $user->{pauseid}, $github_user );
         return;
     }
@@ -139,14 +139,14 @@ sub fetch_github_user {
 
     unless ( $result->success ) {
         $self->log->error(
-            sprintf '%-9s Could not fetch user %s from Github (RL:%d)',
+            sprintf '%-9s Could not fetch user %s from GitHub (RL:%d)',
             $user->{pauseid}, $github_user, $result->ratelimit_remaining );
         return;
     }
 
     $user->{github_data} = $result->content;
     $self->log->info(
-        sprintf '%-9s Successfully fetched user %s from Github (RL:%d)',
+        sprintf '%-9s Successfully fetched user %s from GitHub (RL:%d)',
         $user->{pauseid}, $github_user, $result->ratelimit_remaining );
     return 1;
 }
@@ -160,7 +160,7 @@ sub fetch_github_repos {
     unless ( $result->success ) {
         $self->log->error(
             sprintf
-                '%-9s Could not fetch repos of user %s from Github (RL:%d)',
+                '%-9s Could not fetch repos of user %s from GitHub (RL:%d)',
             $user->{pauseid}, $github_user, $result->ratelimit_remaining );
         return;
     }
@@ -171,7 +171,7 @@ sub fetch_github_repos {
     }
     $self->log->info(
         sprintf
-            '%-9s Successfully fetched repos of user %s from Github (RL:%d)',
+            '%-9s Successfully fetched repos of user %s from GitHub (RL:%d)',
         $user->{pauseid}, $github_user, $result->ratelimit_remaining );
 
     return \@repos;

--- a/templates/layouts/default.html.ep
+++ b/templates/layouts/default.html.ep
@@ -2,7 +2,7 @@
 <html>
 <head>
     <meta charset='utf-8' />
-    <title>Github Meets CPAN<% if ($title) { %>: <%= title %><% } %></title>
+    <title>GitHub Meets CPAN<% if ($title) { %>: <%= title %><% } %></title>
     <link rel="stylesheet" href="<%= url_for '/static/screen.css?3' %>" type="text/css" />
 </head>
 <body>
@@ -17,7 +17,7 @@
         </ul>
     </div>
     <div class="logos">
-        <a href="https://github.com"><img src="<%= url_for '/static/github.png?1' %>" alt="Github" /></a>
+        <a href="https://github.com"><img src="<%= url_for '/static/github.png?1' %>" alt="GitHub" /></a>
         <span class="heart"><a href="<%= url_for '/' %>">&#9829;</a></span>
         <a href="https://metacpan.org"><img src="<%= url_for '/static/cpan.png?1' %>" alt="CPAN" /></a>
     </div>

--- a/templates/parts/user.html.ep
+++ b/templates/parts/user.html.ep
@@ -3,7 +3,7 @@
 <div class="item">
     <ul>
         <li>On MetaCPAN: <a href="<%= $user->{metacpan_url} %>"><%= $user->{metacpan_url} %></a></li>
-        <li>On Github: <a href="<%= $user->{github_data}{html_url} %>"><%= $user->{github_data}{html_url} %></a></li>
+        <li>On GitHub: <a href="<%= $user->{github_data}{html_url} %>"><%= $user->{github_data}{html_url} %></a></li>
         <% if ($user->{github_data}{blog}) { %><li>Blog: <a href="<%= $user->{github_data}{blog} %>"><%= $user->{github_data}{blog} %></a></li><% } %>
         <li>Rank: <%= $user->{rank} %></li>
         <li><a href="https://github.com/<%= $user->{github_user} %>/followers">Followers</a>: <%= $user->{github_data}{followers} %></li>

--- a/templates/root/about.html.ep
+++ b/templates/root/about.html.ep
@@ -2,18 +2,18 @@
 % title 'About';
 <div class="item">
 
-    "Github Meets CPAN" presents a list of users who have set their <a
-    href="https://github.com">Github</a> account at <a
+    "GitHub Meets CPAN" presents a list of users who have set their <a
+    href="https://github.com">GitHub</a> account at <a
     href="https://metacpan.org">MetaCPAN</a>. This app uses the <a
     href="https://github.com/CPAN-API/cpan-api/blob/master/docs/API-docs.md">MetaCPAN
-    API</a> as well as the <a href="http://developer.github.com/v3/">Github
+    API</a> as well as the <a href="http://developer.github.com/v3/">GitHub
     API</a> (<a href="https://metacpan.org/pod/Pithub">Pithub</a>) to gather
     all the information presented here. It is hosted by the MetaCPAN project
     and uses the <a href="http://mojolicious.org/">Mojolicious Web
     Framework</a>. <a href="http://www.fastly.com/">Fastly</a> provides the
     caching layer which makes it so fast.  You can <a
     href="https://github.com/CPAN-API/github-meets-cpan">fork this project on
-    Github</a>.  The guy who was so bored to write this is called <a href="<%=
+    GitHub</a>.  The guy who was so bored to write this is called <a href="<%=
     url_for '/user/PLU' %>">plu</a>. The rank is calculated by this
     formula:<br/>
 
@@ -25,7 +25,7 @@
     <p>To appear on this list, you need to:</p>
     <ul>
     <li>Have an account on <a href="https://metacpan.org">MetaCPAN</a>.
-    <li>Have an account on <a href="https://github.com">Github</a>.
+    <li>Have an account on <a href="https://github.com">GitHub</a>.
     <li>Edit your <a href="https://metacpan.org/account/profile">MetaCPAN profile</a>.
         At the bottom you'll find a <strong>Profiles</strong> section.
         Select GitHub from the drop-down menu and put your github username in the text box that appears.

--- a/templates/root/faq.html.ep
+++ b/templates/root/faq.html.ep
@@ -7,7 +7,7 @@
     </p>
     <p>
         <abbr title="Answer">A:</abbr>
-        You need to set your <a href="https://github.com/">Github</a> account
+        You need to set your <a href="https://github.com/">GitHub</a> account
         at <a href="https://metacpan.org/">MetaCPAN</a> as well as your
         <a href="http://pause.perl.org/">PAUSE</a> account.
     </p>
@@ -16,12 +16,12 @@
 <div class="item">
     <p>
         <abbr title="Question">Q:</abbr>
-        I've set my Github and PAUSE account, but I'm still not in the list?
+        I've set my GitHub and PAUSE account, but I'm still not in the list?
     </p>
     <p>
         <abbr title="Answer">A:</abbr>
         This may have many reasons. First make sure that you have set your
-        <a href="https://github.com/">Github</a> account to your username
+        <a href="https://github.com/">GitHub</a> account to your username
         (e.g.: PLU) and <strong>not</strong> to the full URL to your profile.
         Another reason might be that the list has not been updated in a while,
         see also: "How often is the data being updated?"


### PR DESCRIPTION
Capital "H", not be like "Giþub". Not tested because there are no
instructions on how to run the tests in the README.md and because there
is no .travis.yml file.

I hereby disclaim any ownership of my changes.