### PR TITLE
Use built image

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+COMPOSE_PROJECT_NAME=github-meets-cpan

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     networks:
       - mongo
     ports:
-      - "3000:3000"
+      - "127.0.0.1:${GH_CPAN_SITE_PORT:-3000}:3000"
   web-cron:
     build: .
     command: "/wait-for-it.sh mongodb:27017 -- perl cron/update.pl"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,4 +18,7 @@ services:
     depends_on:
       - mongodb
     volumes:
-      - ${PWD}/environment.json:/code/environment.json
+      - type: bind
+        source: ${MC_CONF_PRIVATE_DIR:-.}/github-meets-cpan/environment.json
+        target: /code/environment.json
+        read_only: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     networks:
       - mongo
   web:
-    build: .
+    image: metacpan/github-meets-cpan:latest
     command: "/wait-for-it.sh mongodb:27017 -- morbo script/app.pl"
     depends_on:
       - mongodb
@@ -15,7 +15,7 @@ services:
     ports:
       - "127.0.0.1:${GH_CPAN_SITE_PORT:-3000}:3000"
   web-cron:
-    build: .
+    image: metacpan/github-meets-cpan:latest
     command: "/wait-for-it.sh mongodb:27017 -- perl cron/update.pl"
     depends_on:
       - mongodb

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,13 +3,15 @@ version: "3.4"
 services:
   mongodb:
     image: mvertes/alpine-mongo:latest
-    ports:
-      - "27017:27017"
+    networks:
+      - mongo
   web:
     build: .
     command: "/wait-for-it.sh mongodb:27017 -- morbo script/app.pl"
     depends_on:
       - mongodb
+    networks:
+      - mongo
     ports:
       - "3000:3000"
   web-cron:
@@ -22,3 +24,7 @@ services:
         source: ${MC_CONF_PRIVATE_DIR:-.}/github-meets-cpan/environment.json
         target: /code/environment.json
         read_only: true
+    networks:
+      - mongo
+networks:
+  mongo:


### PR DESCRIPTION
Update the docker-compose to use the generated image that this repository creates.

The compose file now accepts environment variables to configure the location of the private configuration data and which port to listen on.