### PR TITLE
Remove path attribute from Mojo::Log->new

### DIFF
--- a/lib/GMC/Cron/Update.pm
+++ b/lib/GMC/Cron/Update.pm
@@ -26,7 +26,7 @@ sub new {
     return bless {
         db   => $mongo->get_database('db'),
         home => $args{home},
-        log  => Mojo::Log->new( path => "$args{home}/log/update.log" ),
+        log  => Mojo::Log->new,
         lwp  => LWP::UserAgent->new,
         mcpan =>
             'https://fastapi.metacpan.org/v1/author/_search?q=profile.name:github&size=1000',


### PR DESCRIPTION
The `path` attribute tells Mojo::Log to write to a log file, while in a
container environment, we want the logging to go to STDOUT/STDERR that
way the centralized logging can manage it.

Removing the path attribute will also remove the error when `update.pl`
executes that it can't find the `log` directory that we don't want to
exist anyway.