### PR TITLE
Enforce deploy/push.sh on upstream master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
     - MONGODB_HOST=127.0.0.1
     - RELEASE_TESTING=0
     - DOCKER_IMAGE_NAME=github-meets-cpan
+    # only deploy on the upstream repo
+    - DEPLOY_REPO_SLUG=metacpan/github-meets-cpan
 
 addons:
   apt:

--- a/deploy/push.sh
+++ b/deploy/push.sh
@@ -2,10 +2,24 @@
 
 DEPLOY_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
+if [[ "x${DEPLOY_REPO_SLUG}" != "x${TRAVIS_REPO_SLUG}" ]]; then
+	echo "skip push.sh: only deploy on ${DEPLOY_REPO_SLUG} repo.";
+	exit;
+fi
+
+if [[ "x$DOCKER_HUB_USER" == "x" ]]; then
+	echo "DOCKER_HUB_USER env is not defined.";
+	exit 1;
+fi
+
+if [[ "x$DOCKER_HUB_PASSWD" == "x" ]]; then
+	echo "DOCKER_HUB_PASSWD env is not defined.";
+	exit 1;
+fi
+
 source "${DEPLOY_DIR}/vars.sh"
 
 cd "${DEPLOY_DIR}/.."
 
 docker login -u "$DOCKER_HUB_USER" -p "$DOCKER_HUB_PASSWD"
-
 docker push "$DOCKER_HUB_NAME"


### PR DESCRIPTION
Avoid running `deploy/push.sh` when smoking personal repo.